### PR TITLE
Changed default path to TortoiseProc - fixes #1

### DIFF
--- a/TortoiseSVN.sublime-settings
+++ b/TortoiseSVN.sublime-settings
@@ -1,3 +1,3 @@
 {
-	"tortoiseproc_path": "D:\\Program Files\\TortoiseSVN\\bin\\TortoiseProc.exe"
+	"tortoiseproc_path": "C:\\Program Files\\TortoiseSVN\\bin\\TortoiseProc.exe"
 }


### PR DESCRIPTION
Package is unusable by default for most users, since the required TortoiseProc path is on the D drive — most users have their OS and Program Files on C
