### PR TITLE
Fix type error on file diff

### DIFF
--- a/TortoiseSVN.py
+++ b/TortoiseSVN.py
@@ -6,12 +6,13 @@ import subprocess
 
 class TortoiseSvnCommand(sublime_plugin.WindowCommand):
     def run(self, cmd, paths=None, isHung=False):
-        for index, path in enumerate(paths):
-            if "${PROJECT_PATH}" in path:
-                project_data  = sublime.active_window().project_data()
-                project_folder = project_data['folders'][0]['path']
-                path = path.replace("${PROJECT_PATH}", project_folder);
-                paths[index] = path	
+        if paths is not None:
+            for index, path in enumerate(paths):
+              if "${PROJECT_PATH}" in path:
+                  project_data  = sublime.active_window().project_data()
+                  project_folder = project_data['folders'][0]['path']
+                  path = path.replace("${PROJECT_PATH}", project_folder);
+                  paths[index] = path	
         dir = self.get_path(paths)
 
         if not dir:


### PR DESCRIPTION
Fixes an error - when paths was not set it is not iterable and there was a type error, breaking some features. Bug introduced in 1dc74aef6045befdc7d38203cf87851dde542415
