### PR TITLE
Add the Check for Modification command

### DIFF
--- a/Side Bar.sublime-menu
+++ b/Side Bar.sublime-menu
@@ -7,5 +7,6 @@
 	{ "caption": "SVN Log", "command": "svn_log", "args": {"paths":[]}},
 	{ "caption": "SVN Blame", "command": "svn_blame", "args": {"paths":[]}},
 	{ "caption": "SVN Switch", "command": "svn_switch", "args": {"paths":[]}},
+        { "caption": "SVN CheckModifications",   "command": "svn_repostatus",   "args": {"paths":[]}},
 	{ "caption": "-", "id": "end" }
 ]

--- a/TortoiseSVN.py
+++ b/TortoiseSVN.py
@@ -26,6 +26,10 @@ class TortoiseSvnCommand(sublime_plugin.WindowCommand):
                 ' please config setting file' '\n   --sublime-TortoiseSVN')
             raise
 
+        # If the command is repostatus I just change the path to the view's dir
+        if (cmd == "repostatus" and os.path.isfile(dir)):
+            dir = (os.path.dirname(dir))
+
         proce = subprocess.Popen('"' + tortoiseproc_path + '"' + 
             ' /command:' + cmd + ' /path:"%s"' % dir , stdout=subprocess.PIPE)
 
@@ -101,6 +105,10 @@ class SvnSwitchCommand(TortoiseSvnCommand):
 class SvnDiffCommand(TortoiseSvnCommand):
     def run(self, paths=None):
         TortoiseSvnCommand.run(self, 'diff', paths)
+
+class SvnRepostatusCommand(TortoiseSvnCommand):
+    def run(self, paths=None):
+         TortoiseSvnCommand.run(self, 'repostatus', paths)
 
 
 class SvnBlameCommand(TortoiseSvnCommand):

--- a/TortoiseSVN.sublime-commands
+++ b/TortoiseSVN.sublime-commands
@@ -2,5 +2,6 @@
 	{ "caption": "TortoiseSVN: Update", "command": "svn_update" },
 	{ "caption": "TortoiseSVN: Commit", "command": "svn_commit" },
 	{ "caption": "TortoiseSVN: Revert", "command": "svn_revert" },
+        { "caption": "TortoiseSVN: CheckModifications", "command": "svn_repostatus" },
 	{ "caption": "TortoiseSVN: Log", "command": "svn_log" }
 ]


### PR DESCRIPTION
Hi,
in my workday I use a lot this "Check for modification" operation in Tortoise SVN. This is an "enhanced" Diff view. It works generally with a directory and show you every modified file in that directory.

I developed in the TortoiseSVN plugin for my use this "CheckModification" function both with the right-click on a file/directory in the left bar and in the "scroll-down" menu. If you have a file in your view and you execute a "CheckModification" command you'll obtain a dialog with every modified file of the directory in which you're working.

I don't know if this can be useful for you, but I thought it could be better propose it directly with a pull req. If you think this is useful for someone else (than me) the work is done. (I hope... complete.)

Thank you!
David
